### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM java
+FROM maven:3.8.6-eclipse-temurin-11 AS build
 ENV version=1.0.8
 MAINTAINER Tobias Eljasik-Swoboda ${version}
-EXPOSE 8080/tcp
-EXPOSE 8081/tcp
-ADD ./target/classifier-trainer-${version}-SNAPSHOT.jar /opt/classifier-trainer/target/classifier-trainer-${version}-SNAPSHOT.jar
-ADD ./classifier-trainer.yml /opt/classifier-trainer/target/classifier-trainer.yml
-RUN java -jar /opt/classifier-trainer/target/classifier-trainer-${version}-SNAPSHOT.jar server /opt/classifier-trainer/target/classifier-trainer.yml
+COPY src /home/app/src
+COPY pom.xml /home/app
+COPY classifier-trainer.yml /home/app/classifier-trainer.yml
+RUN mvn -f /home/app/pom.xml clean package
+
+FROM openjdk:20
+ENV version=1.0.8
+COPY --from=build /home/app/target/classifier-trainer-${version}-SNAPSHOT.jar /usr/local/lib/classifier.jar
+COPY --from=build /home/app/classifier-trainer.yml /usr/local/lib/classifier-trainer.yml
+EXPOSE 8080
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "/usr/local/lib/classifier.jar", "server", "/usr/local/lib/classifier-trainer.yml"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ docker run -d -p 8080:8080 -p 8081:8081 --rm -it classifier:latest
 - `-i` Keep STDIN open even if not attached
 - `-t` Allocate a pseudo-TTY
 
+3. display java log
+
+```bash
+docker logs --follow <DOCKER-ID>
+```
+
 ## change log:
 
 - 0.0.1: implementation of configurable /metadata

--- a/README.md
+++ b/README.md
@@ -10,7 +10,28 @@ The Dockerfile to see which commands you need to run the service on a Linux mach
 
 Or you can just run the Docker container including everything necessary. 
 
-Version change log:
+## build and start docker container
+
+1. create docker-image:
+
+```bash
+docker build -t classifier .
+```
+
+2. run docker-image:
+
+```bash
+docker run -d -p 8080:8080 -p 8081:8081 --rm -it classifier:latest
+```
+
+*Options:*
+- `-d` Run container in background and print container ID 
+- `-p` Publish a container's port(s) to the host
+- `--rm` Automatically remove the container when it exits
+- `-i` Keep STDIN open even if not attached
+- `-t` Allocate a pseudo-TTY
+
+## change log:
 
 - 0.0.1: implementation of configurable /metadata
 - 0.1.1: implementation of GET /documents/$x

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,8 @@
 </description>
   <properties>
   	<dropwizard.version>1.3.5</dropwizard.version>
+    <maven.compiler.source>7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
   <dependencies>
   	<dependency>


### PR DESCRIPTION
- resolves issue with java dependency #1 
- build maven-application by docker file (not by local machine)
- prevent running the app when docker image is build (it's bad practice)
- split "stages": 
       (1) create docker image with `docker build` 
       (2) run docker image with `docker run`
- documentation on how to create the docker image in the readme.md